### PR TITLE
Add lidar ignored actors support

### DIFF
--- a/Docs/ref_sensors.md
+++ b/Docs/ref_sensors.md
@@ -277,6 +277,7 @@ The rotation of the LIDAR can be tuned to cover a specific angle on every simula
 | `dropoff_zero_intensity`        | float  | 0.4   | For the intensity based drop-off, the probability of each point with zero intensity being dropped.    |
 | `sensor_tick`      | float  | 0.0   | Simulation seconds between sensor captures (ticks). |
 | `noise_stddev`     | float  | 0.0   | Standard deviation of the noise model to disturb each point along the vector of its raycast. |
+| `ignored_actors`   | string | ""    | Comma-separated list of actor IDs ignored when computing hits. |
 
 
 

--- a/LibCarla/source/carla/client/ServerSideSensor.cpp
+++ b/LibCarla/source/carla/client/ServerSideSensor.cpp
@@ -65,6 +65,10 @@ namespace client {
     GetEpisode().Lock()->Send(*this,message);
   }
 
+  void ServerSideSensor::SetLidarIgnoredActors(const std::vector<ActorId> &Ids) {
+    GetEpisode().Lock()->SetLidarIgnoredActors(*this, Ids);
+  }
+
   void ServerSideSensor::ListenToGBuffer(uint32_t GBufferId, CallbackFunctionType callback) {
     log_debug(GetDisplayId(), ": subscribing to gbuffer stream");
     RELEASE_ASSERT(GBufferId < GBufferTextureCount);

--- a/LibCarla/source/carla/client/ServerSideSensor.h
+++ b/LibCarla/source/carla/client/ServerSideSensor.h
@@ -59,6 +59,8 @@ namespace client {
     /// Send data via this sensor
     void Send(std::string message);
 
+    void SetLidarIgnoredActors(const std::vector<ActorId> &Ids);
+
     /// @copydoc Actor::Destroy()
     ///
     /// Additionally stop listening.

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -684,9 +684,13 @@ namespace detail {
     return _pimpl->CallAndWait<bool>("is_sensor_enabled_for_ros", thisToken.get_stream_id());
   }
 
-  void Client::Send(rpc::ActorId ActorId, std::string message) {
-    _pimpl->AsyncCall("send", ActorId, message);
-  }
+void Client::Send(rpc::ActorId ActorId, std::string message) {
+  _pimpl->AsyncCall("send", ActorId, message);
+}
+
+void Client::SetLidarIgnoredActors(rpc::ActorId ActorId, const std::vector<ActorId> &Ids) {
+  _pimpl->AsyncCall("set_lidar_ignored_actors", ActorId, Ids);
+}
 
   void Client::SubscribeToGBuffer(
       rpc::ActorId ActorId,

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -439,7 +439,9 @@ namespace detail {
         rpc::ActorId ActorId,
         uint32_t GBufferId);
 
-    void Send(rpc::ActorId ActorId, std::string message);
+  void Send(rpc::ActorId ActorId, std::string message);
+
+  void SetLidarIgnoredActors(rpc::ActorId ActorId, const std::vector<ActorId> &Ids);
 
     void DrawDebugShape(const rpc::DebugShape &shape);
 

--- a/LibCarla/source/carla/client/detail/Simulator.cpp
+++ b/LibCarla/source/carla/client/detail/Simulator.cpp
@@ -451,6 +451,10 @@ EpisodeProxy Simulator::GetCurrentEpisode() {
     _client.Send(sensor.GetId(), message);
   }
 
+  void Simulator::SetLidarIgnoredActors(const Sensor &sensor, const std::vector<ActorId> &Ids) {
+    _client.SetLidarIgnoredActors(sensor.GetId(), Ids);
+  }
+
   // =========================================================================
   /// -- Texture updating operations
   // =========================================================================

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -712,7 +712,11 @@ namespace detail {
         Actor & sensor,
         uint32_t gbuffer_id);
 
-    void Send(const Sensor &sensor, std::string message);        
+    void Send(const Sensor &sensor, std::string message);
+
+    void SetLidarIgnoredActors(const Sensor &sensor, const std::vector<ActorId> &Ids) {
+      _client.SetLidarIgnoredActors(sensor.GetId(), Ids);
+    }
 
     /// @}
     // =========================================================================

--- a/PythonAPI/carla/source/libcarla/Sensor.cpp
+++ b/PythonAPI/carla/source/libcarla/Sensor.cpp
@@ -41,6 +41,7 @@ void export_sensor() {
     .def("disable_for_ros", &cc::ServerSideSensor::DisableForROS)
     .def("is_enabled_for_ros", &cc::ServerSideSensor::IsEnabledForROS)
     .def("send", &cc::ServerSideSensor::Send, (arg("message")))
+    .def("set_ignored_actors", &cc::ServerSideSensor::SetLidarIgnoredActors, (arg("ids")))
     .def(self_ns::str(self_ns::self))
   ;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -987,6 +987,13 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
   EnableEgoMotion.Type = EActorAttributeType::Bool;
   EnableEgoMotion.RecommendedValues = { TEXT("true") };
 
+  // Actors ignored by this lidar
+  FActorVariation IgnoredActors;
+  IgnoredActors.Id = TEXT("ignored_actors");
+  IgnoredActors.Type = EActorAttributeType::String;
+  IgnoredActors.RecommendedValues = { TEXT("") };
+  IgnoredActors.bRestrictToRecommended = false;
+
   if (Id == "ray_cast") {
     Definition.Variations.Append({
       Channels,
@@ -1002,7 +1009,8 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
       DropOffAtZeroIntensity,
       StdDevLidar,
       HorizontalFOV,
-      EnableEgoMotion});
+      EnableEgoMotion,
+      IgnoredActors});
   }
   else if (Id == "ray_cast_semantic") {
     Definition.Variations.Append({
@@ -1012,7 +1020,8 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
       Frequency,
       UpperFOV,
       LowerFOV,
-      HorizontalFOV});
+      HorizontalFOV,
+      IgnoredActors});
   }
   else if (Id == "ray_cast_surface_normals") {
     Definition.Variations.Append({
@@ -1028,7 +1037,8 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
       DropOffIntensityLimit,
       DropOffAtZeroIntensity,
       StdDevLidar,
-      HorizontalFOV});
+      HorizontalFOV,
+      IgnoredActors});
   }
   else if (Id == "ray_cast_complete") {
     Definition.Variations.Append({
@@ -1045,7 +1055,8 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
       DropOffAtZeroIntensity,
       StdDevLidar,
       HorizontalFOV,
-      EnableEgoMotion});
+      EnableEgoMotion,
+      IgnoredActors});
   }
   else {
     DEBUG_ASSERT(false);
@@ -2083,6 +2094,20 @@ void UActorBlueprintFunctionLibrary::SetLidar(
       RetrieveActorAttributeToFloat("noise_stddev", Description.Variations, Lidar.NoiseStdDev);
   Lidar.EnableEgoMotion =
       RetrieveActorAttributeToBool("enable_ego_motion", Description.Variations, Lidar.EnableEgoMotion);
+
+  Lidar.IgnoredActorIds.Empty();
+  const FString IgnoredStr =
+      RetrieveActorAttributeToString("ignored_actors", Description.Variations, TEXT(""));
+  if (!IgnoredStr.IsEmpty())
+  {
+    TArray<FString> Split;
+    IgnoredStr.ParseIntoArray(Split, TEXT(","), true);
+    for (const FString& Elem : Split)
+    {
+      int32 Id = FCString::Atoi(*Elem);
+      Lidar.IgnoredActorIds.Add(Id);
+    }
+  }
 }
 
 void UActorBlueprintFunctionLibrary::SetGnss(

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LidarDescription.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/LidarDescription.h
@@ -73,4 +73,8 @@ struct CARLA_API FLidarDescription
 
   UPROPERTY(EditAnywhere)
   float NoiseStdDev = 0.0f;
+
+  /// Actors ignored when performing ray-cast traces
+  UPROPERTY(EditAnywhere)
+  TArray<int32> IgnoredActorIds;
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastCompleteLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastCompleteLidar.cpp
@@ -255,11 +255,32 @@ void ARayCastCompleteLidar::ComputeAndSaveDetections(const FTransform& SensorTra
           FVector  end   = start + dir * Description.Range;
 
           // Lancement du ray‐cast UE4
-          FHitResult hit;
-          bool bHit = GetWorld()->LineTraceSingleByChannel(
-              hit, start, end, ECC_GameTraceChannel2, TraceParams);
+          TArray<FHitResult> hits;
+          bool bHit = GetWorld()->LineTraceMultiByChannel(
+              hits, start, end, ECC_GameTraceChannel2, TraceParams);
 
+          FHitResult hit;
           if (!bHit) {
+            continue;
+          }
+          for (const FHitResult& testHit : hits)
+          {
+            const AActor* actor = testHit.Actor.Get();
+            int32 id = 0;
+            if (actor)
+            {
+              const FCarlaActor* view = GetEpisode().GetActorRegistry().FindCarlaActor(actor);
+              if (view)
+                id = view->GetActorId();
+            }
+            if (!Description.IgnoredActorIds.Contains(id))
+            {
+              hit = testHit;
+              break;
+            }
+          }
+          if (!hit.bBlockingHit)
+          {
             continue;
           }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastLidar.cpp
@@ -398,11 +398,32 @@ void ARayCastLidar::ComputeAndSaveDetections(const FTransform& SensorTransform)
           FVector  end   = start + dir * Description.Range;
 
           // Lancement du ray‐cast UE4
-          FHitResult hit;
-          bool bHit = GetWorld()->LineTraceSingleByChannel(
-              hit, start, end, ECC_GameTraceChannel2, TraceParams);
+          TArray<FHitResult> hits;
+          bool bHit = GetWorld()->LineTraceMultiByChannel(
+              hits, start, end, ECC_GameTraceChannel2, TraceParams);
 
+          FHitResult hit;
           if (!bHit) {
+            continue;
+          }
+          for (const FHitResult& testHit : hits)
+          {
+            const AActor* actor = testHit.Actor.Get();
+            int32 id = 0;
+            if (actor)
+            {
+              const FCarlaActor* view = GetEpisode().GetActorRegistry().FindCarlaActor(actor);
+              if (view)
+                id = view->GetActorId();
+            }
+            if (!Description.IgnoredActorIds.Contains(id))
+            {
+              hit = testHit;
+              break;
+            }
+          }
+          if (!hit.bBlockingHit)
+          {
             continue;
           }
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.cpp
@@ -49,6 +49,11 @@ void ARayCastSemanticLidar::Set(const FLidarDescription &LidarDescription)
   PointsPerChannel.resize(Description.Channels);
 }
 
+void ARayCastSemanticLidar::SetIgnoredActors(const TArray<int32>& ActorIds)
+{
+  Description.IgnoredActorIds = ActorIds;
+}
+
 void ARayCastSemanticLidar::CreateLasers()
 {
   const auto NumberOfLasers = Description.Channels;
@@ -246,8 +251,9 @@ bool ARayCastSemanticLidar::ShootLaser(const float VerticalAngle, const float Ho
   const auto Range = Description.Range;
   FVector EndTrace = Range * UKismetMathLibrary::GetForwardVector(ResultRot) + LidarBodyLoc;
 
-  GetWorld()->ParallelLineTraceSingleByChannel(
-    HitInfo,
+  TArray<FHitResult> Hits;
+  GetWorld()->ParallelLineTraceMultiByChannel(
+    Hits,
     LidarBodyLoc,
     EndTrace,
     ECC_GameTraceChannel2,
@@ -255,10 +261,18 @@ bool ARayCastSemanticLidar::ShootLaser(const float VerticalAngle, const float Ho
     FCollisionResponseParams::DefaultResponseParam
   );
 
-  if (HitInfo.bBlockingHit) {
-    HitResult = HitInfo;
-    return true;
-  } else {
-    return false;
+  for (const FHitResult& TestHit : Hits) {
+    const AActor* Actor = TestHit.Actor.Get();
+    int32 Id = 0;
+    if (Actor) {
+      const FCarlaActor* View = GetEpisode().GetActorRegistry().FindCarlaActor(Actor);
+      if (View)
+        Id = View->GetActorId();
+    }
+    if (!Description.IgnoredActorIds.Contains(Id)) {
+      HitResult = TestHit;
+      return true;
+    }
   }
+  return false;
 }

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Sensor/RayCastSemanticLidar.h
@@ -39,6 +39,9 @@ public:
   virtual void Set(const FActorDescription &Description) override;
   virtual void Set(const FLidarDescription &LidarDescription);
 
+  UFUNCTION(BlueprintCallable)
+  void SetIgnoredActors(const TArray<int32>& ActorIds);
+
 protected:
   virtual void PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaTime) override;
 

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1012,6 +1012,36 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
     return R<void>::Success();
   };
 
+  BIND_SYNC(set_lidar_ignored_actors) << [this](
+      cr::ActorId ActorId,
+      std::vector<uint32_t> IgnoredIds) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
+    if (!CarlaActor)
+    {
+      return RespondError(
+          "set_lidar_ignored_actors",
+          ECarlaServerResponse::ActorNotFound,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+    ARayCastSemanticLidar* Lidar = Cast<ARayCastSemanticLidar>(CarlaActor->GetActor());
+    if (!Lidar)
+    {
+      return RespondError(
+          "set_lidar_ignored_actors",
+          ECarlaServerResponse::ActorTypeMismatch,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+    TArray<int32> IdArray;
+    for (uint32_t Id : IgnoredIds)
+    {
+      IdArray.Add((int32)Id);
+    }
+    Lidar->SetIgnoredActors(IdArray);
+    return R<void>::Success();
+  };
+
   // ~~ Actor physics ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   BIND_SYNC(set_actor_location) << [this](


### PR DESCRIPTION
## Summary
- support IgnoredActorIds option for Lidars
- expose ignored actors attr in actor blueprint and python API
- implement multi-hit trace skipping ignored actors
- document new lidar option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f59bcf4a883239515670eb4ec5fae